### PR TITLE
Use configured Gemini API key env var

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -4,7 +4,8 @@ import { GoogleGenAI, Type } from "@google/genai";
 import { ResumeData } from "../types";
 
 // Initialize API Key securely on the server
-const GEMINI_API_KEY = process.env.API_KEY || '';
+const GEMINI_API_KEY =
+  process.env.GEMINI_API_KEY || process.env.API_KEY || '';
 
 const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
 


### PR DESCRIPTION
## Summary
- align Gemini API client to read the documented GEMINI_API_KEY variable with a fallback to API_KEY

## Testing
- npm run lint *(fails: Invalid project directory provided: /workspace/resume-builder/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693999116b18832ebec8f137e71454f4)