### PR TITLE
Remove unsupported context compression from live interview config

### DIFF
--- a/services/liveInterview.ts
+++ b/services/liveInterview.ts
@@ -181,10 +181,6 @@ export const runLiveInterviewTurn = async (
             },
           },
         },
-        contextWindowCompression: {
-          triggerTokens: '25600',
-          slidingWindow: { targetTokens: '12800' },
-        },
       },
     });
 


### PR DESCRIPTION
## Summary
- remove the unsupported contextWindowCompression block from the live interview session config to avoid invalid-argument closures

## Testing
- npm run lint (fails: Invalid project directory provided, no such directory: /workspace/resume-builder/lint)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694447608d68832e9d9619eda38f4023)